### PR TITLE
Fix handling of 'A' records, which were previously ignored.

### DIFF
--- a/nice-route53.js
+++ b/nice-route53.js
@@ -102,6 +102,15 @@ function convertListResourceRecordSetsResponseToRecords(response) {
             ttl  : recordSet.TTL,
         };
 
+        // Alias
+        if ( record.type == 'A' && recordSet.AliasTarget ) {
+            record.values = [
+                recordSet.AliasTarget.DNSName
+            ];
+
+            return records.push(record);
+        }
+
         // if there are no resource records, then this might be an Alias!
         if ( !recordSet.ResourceRecords ) return;
 

--- a/test/ListResourceRecordSetResponse-1.xml
+++ b/test/ListResourceRecordSetResponse-1.xml
@@ -23,12 +23,10 @@
       <ResourceRecordSet>
          <Name>example.com.</Name>
          <Type>A</Type>
-         <TTL>604800</TTL>
-         <ResourceRecords>
-            <ResourceRecord>
-               <Value>1.2.3.4</Value>
-            </ResourceRecord>
-         </ResourceRecords>
+         <AliasTarget>
+             <HostedZoneId>AKFAKEZONEID</HostedZoneId>
+             <DNSName>a.domain.override</DNSName>
+         </AliasTarget>
       </ResourceRecordSet>
       <ResourceRecordSet>
          <Name>example.com.</Name>


### PR DESCRIPTION
In the current version of nice-route53 'A' records are not returned from the #records() call, as they do not contain a ResourceRecords entry, instead having an AliasTarget.

I have updated the tests and the code itself to handle this scenario, hope it's inline with your contribution format.
