### PR TITLE
Corrected IsTruncated handling in Route53.prototype.zones.

### DIFF
--- a/nice-route53.js
+++ b/nice-route53.js
@@ -179,7 +179,7 @@ Route53.prototype.zones = function(callback) {
             zones = zones.concat(convertListHostedZonesResponse(hostedZones));
 
             // if this response contains IsTruncated, then we need to re-query
-            if ( response.IsTruncated === 'true' ) {
+            if ( response.IsTruncated === true ) {
                 return listHostedZones(response.NextMarker, next);
             }
 
@@ -317,7 +317,7 @@ Route53.prototype.records = function(zoneId, callback) {
                 records = records.concat(newRecords);
                 // if this response contains IsTruncated, then we need to re-query
                 if ( response.IsTruncated === true ) {
-                    
+
                     return listResourceRecords(
                         response.NextRecordName,
                         response.NextRecordType,
@@ -352,7 +352,7 @@ Route53.prototype.setRecord = function(opts, pollEvery, callback) {
     var args = {
         HostedZoneId : opts.zoneId,
         ChangeBatch : {
-            Changes: [],    
+            Changes: [],
         }
     };
     if ( opts.comment ) {
@@ -438,7 +438,7 @@ Route53.prototype.delRecord = function(opts, pollEvery, callback) {
     var args = {
         HostedZoneId : opts.zoneId,
         ChangeBatch : {
-            Changes: [],    
+            Changes: [],
         }
     };
 


### PR DESCRIPTION
The comparison for IsTruncated was === 'true' when it should have been
=== true, the returned type from the AWS-SDK is a boolean not a string.
The rest of the IsTruncated comparisons in the file are boolean, this
one might have been missed.