### PR TITLE
lib: fix bug when record list is paginated

### DIFF
--- a/nice-route53.js
+++ b/nice-route53.js
@@ -296,18 +296,12 @@ Route53.prototype.records = function(zoneId, callback) {
 
         function listResourceRecords(nextName, nextType, nextIdentifier, callback) {
             if ( nextName ) {
-                args.Name = nextName;
-                args.Type = nextType;
+                args.StartRecordType = nextType;
+                args.StartRecordName = nextName;
                 if ( nextIdentifier ) {
-                    delete args.Name;
-                    delete args.Type;
-                    args.StartRecordType = nextType;
-                    args.StartRecordName = nextName;
-                    //args.StartRecordIdentifier = nextIdentifier;
-
+                    args.StartRecordIdentifier = nextIdentifier;
                 }
             }
-
             // get the records
             self.client.listResourceRecordSets(args, function(err, response) {
                 if (err) return callback(makeError(err));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nice-route53",
   "description": "a nicer API to Amazon's Route53",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "nice-route53.js",
   "homepage": "https://github.com/chilts/nice-route53/",
   "repository": {

--- a/test/records.js
+++ b/test/records.js
@@ -61,14 +61,13 @@ test('records.js: records() - with multiple calls', function(t) {
 
     // mock the ListResourceRecordSetsResponse
     route53
-        .get('/2013-04-01/hostedzone/Z1WXHQ7IJR9FPX/rrset?name=chilts.com.&type=SOA')
+        .get('/2013-04-01/hostedzone/Z1WXHQ7IJR9FPX/rrset?identifier=testIdentifier&name=chilts.com.&type=SOA')
         .replyWithFile(200, __dirname + '/ListResourceRecordSetResponse-Part2.xml')
     ;
 
     // get the zones
     r53.records('Z1WXHQ7IJR9FPX', function(err, records) {
         t.equal(err, null, 'There is no error');
-
         t.equal(records.length, 4, 'there are 4 resource records');
 
         t.equal(records[0].type, 'A', 'the first record are the A records');


### PR DESCRIPTION
If `response.NextRecordIdentifier` is not set, the following call to
`listResourceRecordSets` will have a malformed params.

Refs: #9 