### PR TITLE
Fixes #20. Handle deletion of one element of a set.

### DIFF
--- a/nice-route53.js
+++ b/nice-route53.js
@@ -525,7 +525,9 @@ Route53.prototype.delRecord = function(opts, pollEvery, callback) {
         if (err) return callback(err);
         // loop through the records finding the one we want (if any)
         records.forEach(function(record) {
-            if ( opts.name === record.name && opts.type === record.type ) {
+            if ( opts.name === record.name && opts.type === record.type &&
+                 ( ! opts.setIdentifier ||
+                   opts.setIdentifier == record.setIdentifier )) {
                 args.ChangeBatch.Changes.push({
                     Action : 'DELETE',
                     ResourceRecordSet: {


### PR DESCRIPTION
Consider a set of records using the Weighted routing policy. There are
multiple records with the same name but different SetIdentifier values. If a
setIdentifier is provided in to delRecord, only that particular record should
be deleted; not all with the given name. This patch ensures that if a
setIdentifier is provided to delRecord, only that record in the set will be
deleted.